### PR TITLE
Clean up handling of ready notification

### DIFF
--- a/polling.go
+++ b/polling.go
@@ -29,11 +29,19 @@ func newPollingProcessor(config Config, requestor *requestor) *pollingProcessor 
 func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 	pp.config.Logger.Printf("Starting LaunchDarkly polling processor with interval: %+v", pp.config.PollInterval)
 	go func() {
+		var readyOnce sync.Once
+		notifyReady := func() {
+			readyOnce.Do(func() {
+				close(closeWhenReady)
+			})
+		}
+		// Ensure we stop waiting for initialization if we exit, even if initialization fails
+		defer notifyReady()
+
 		for {
 			select {
 			case <-pp.quit:
 				pp.config.Logger.Printf("Polling Processor closed.")
-				close(closeWhenReady)
 				return
 			default:
 				then := time.Now()
@@ -41,14 +49,14 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 				if err == nil {
 					pp.setInitializedOnce.Do(func() {
 						pp.isInitialized = true
-						close(closeWhenReady)
+						notifyReady()
 					})
 				} else {
 					pp.config.Logger.Printf("ERROR: Error when requesting feature updates: %+v", err)
 					if hse, ok := err.(*HttpStatusError); ok {
 						if hse.Code == 401 {
 							pp.config.Logger.Printf("ERROR: Received 401 error, no further polling requests will be made since SDK key is invalid")
-							close(closeWhenReady)
+							notifyReady()
 							return
 						}
 					}

--- a/polling.go
+++ b/polling.go
@@ -57,6 +57,7 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 						if hse.Code == 401 {
 							pp.config.Logger.Printf("ERROR: Received 401 error, no further polling requests will be made since SDK key is invalid")
 							notifyReady()
+							return
 						}
 					}
 				}

--- a/polling.go
+++ b/polling.go
@@ -57,7 +57,6 @@ func (pp *pollingProcessor) Start(closeWhenReady chan<- struct{}) {
 						if hse.Code == 401 {
 							pp.config.Logger.Printf("ERROR: Received 401 error, no further polling requests will be made since SDK key is invalid")
 							notifyReady()
-							return
 						}
 					}
 				}


### PR DESCRIPTION
I've created this PR to try to resolve some issues.  Sorry I wasn't clearer about where I thought the duplicate close calls might happen.  Hope this makes sense.  I also am trying to use `defer` to DRY up a few things.  Once this change is in, we'll run some tests on our integration test suite and we should be able to merge it next week.  

